### PR TITLE
ddi: client: replace deprecated aiohttp.Timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
       setup_requires=['setuptools_scm'],
       install_requires=[
           'aiohttp>=2.0.0',
-          'gbulb>=0.5'
+          'gbulb>=0.5',
+          'async-timeout>=3.0.0',
       ],
       packages=find_packages(),
       include_package_data=True,


### PR DESCRIPTION
Use timeout keyword for session.get(), session.put() and
session.post(). Use async-timeout's context manager to allow content
reading just like before.

Signed-off-by: Bastian Stender <bst@pengutronix.de>