### PR TITLE
Use readchunk and fix timeouts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
       url='https://github.com/rauc/rauc-hawkbit',
       setup_requires=['setuptools_scm'],
       install_requires=[
-          'aiohttp>=2.0.0',
+          'aiohttp>=3.3.2',
           'gbulb>=0.5'
       ],
       packages=find_packages(),


### PR DESCRIPTION
Hi again o/

I think this is a bug, or at least in our case (^1) it caused a `aiohttp timeout` while reading chunks.

---

When the chunk_size is that small (512 bytes), the loop in which we `read` is executed so fast that our CPU usage goes up to 100% since we practically don't `await` anymore. This caused a hanging state ultimately resulting in a timeout (after 60s). Increasing the `chunk_size` to 512kb instead of 512 bytes seemed reasonable (or was this chosen to be sooo small on purpose?).

^1: We use an ARM Cortex A7, single core (imx6ul)
