### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ addons:
     packages:
       - python3-gi
 install:
+  - pip install --upgrade setuptools
   - pip install --upgrade pytest pytest-mock pytest-cov codecov
   - pip install tox-travis
-  - pip install sphinx sphinx_rtd_theme
+  - pip install sphinx==1.6.7 sphinx_rtd_theme
   - pip install aiohttp
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 python:
   - "3.5"
   - "3.6"
+addons:
+  apt:
+    packages:
+      - python3-gi
 install:
   - pip install --upgrade pytest pytest-mock pytest-cov codecov
   - pip install tox-travis


### PR DESCRIPTION
- fix missing [python3-gi](https://travis-ci.org/rauc/rauc-hawkbit/jobs/295110824#L605)
- set fixed sphinx version to 1.6.7 to circumvent broken/undocumented sphinx setuptools integration