### PR TITLE
Added Option to use GatewayToken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Then setup your configuration file:
   tenant_id = DEFAULT
   target_name = test-target
   auth_token = bhVahL1Il1shie2aj2poojeChee6ahShu
+  auth_token_type = TargetToken
   mac_address = 12:34:56:78:9A:BC
   bundle_download_location = /tmp/bundle.raucb
 
@@ -67,7 +68,7 @@ simply setup an interface between RAUC and hawkBit.
 
   async with aiohttp.ClientSession() as session:
       client = RaucDBUSDDIClient(session, HOST, SSL, TENANT_ID, TARGET_NAME,
-                                 AUTH_TOKEN, ATTRIBUTES, BUNDLE_DL_LOCATION,
+                                 AUTH_TOKEN, AUTH_TOKEN_TYPE, ATTRIBUTES, BUNDLE_DL_LOCATION,
                                  result_callback, step_callback)
       await client.start_polling()
 
@@ -80,7 +81,7 @@ use the DDIClient class.
 
    ...
 
-   ddi = DDIClient(session, host, ssl, auth_token, tenant_id, target_name)
+   ddi = DDIClient(session, host, ssl, auth_token, auth_token_type, tenant_id, target_name)
    base = await self.ddi()
 
    if '_links' in base:

--- a/bin/rauc-hawkbit-client
+++ b/bin/rauc-hawkbit-client
@@ -64,6 +64,10 @@ async def main():
     TENANT_ID = config.get('client', 'tenant_id')
     TARGET_NAME = config.get('client', 'target_name')
     AUTH_TOKEN = config.get('client', 'auth_token')
+    if config.has_option('client', 'auth_token_type'):
+        AUTH_TOKEN_TYPE = config.get('client', 'auth_token_type')
+    else:
+        AUTH_TOKEN_TYPE = "TargetToken"
     ATTRIBUTES = {'MAC':config.get('client', 'mac_address')}
     BUNDLE_DL_LOCATION = config.get('client', 'bundle_download_location')
 
@@ -77,7 +81,7 @@ async def main():
 
     async with aiohttp.ClientSession() as session:
         client = RaucDBUSDDIClient(session, HOST, SSL, TENANT_ID, TARGET_NAME,
-                                   AUTH_TOKEN, ATTRIBUTES, BUNDLE_DL_LOCATION,
+                                   AUTH_TOKEN, AUTH_TOKEN_TYPE, ATTRIBUTES, BUNDLE_DL_LOCATION,
                                    result_callback, step_callback)
         await client.start_polling()
 

--- a/rauc_hawkbit/ddi/client.py
+++ b/rauc_hawkbit/ddi/client.py
@@ -42,12 +42,12 @@ class DDIClient(object):
         429: 'Too many requests.'
     }
 
-    def __init__(self, session, host, ssl, auth_token, tenant_id, controller_id, timeout=10):
+    def __init__(self, session, host, ssl, auth_token, auth_token_type, tenant_id, controller_id, timeout=10):
         self.session = session
         self.host = host
         self.ssl = ssl
         self.logger = logging.getLogger('rauc_hawkbit')
-        self.headers = {'Authorization': 'TargetToken {}'.format(auth_token)}
+        self.headers = {'Authorization': auth_token_type + ' {}'.format(auth_token)}
         self.tenant = tenant_id
         self.controller_id = controller_id
         self.timeout = timeout

--- a/rauc_hawkbit/rauc_dbus_ddi_client.py
+++ b/rauc_hawkbit/rauc_dbus_ddi_client.py
@@ -24,14 +24,14 @@ class RaucDBUSDDIClient(AsyncDBUSClient):
     Client broker communicating with RAUC via DBUS and HawkBit DDI HTTP
     interface.
     """
-    def __init__(self, session, host, ssl, tenant_id, target_name, auth_token,
+    def __init__(self, session, host, ssl, tenant_id, target_name, auth_token, auth_token_type,
                  attributes, bundle_dl_location, result_callback, step_callback=None, lock_keeper=None):
         super(RaucDBUSDDIClient, self).__init__()
 
         self.attributes = attributes
 
         self.logger = logging.getLogger('rauc_hawkbit')
-        self.ddi = DDIClient(session, host, ssl, auth_token, tenant_id, target_name)
+        self.ddi = DDIClient(session, host, ssl, auth_token, auth_token_type, tenant_id, target_name)
         self.action_id = None
 
         bundle_dir = os.path.dirname(bundle_dl_location)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,7 +32,7 @@ def create_app(loop):
 async def test_get_resource_valid(test_client):
     client = await test_client(create_app)
 
-    ddi = DDIClient(client.session, '{}:{}'.format(client.host, client.port), False, None, '/DEFAULT', 'test-target')
+    ddi = DDIClient(client.session, '{}:{}'.format(client.host, client.port), False, None, 'TargetToken', '/DEFAULT', 'test-target')
     resp = await ddi.get_resource('{tenant}/controller/v1/{controllerId}')
 
     assert 'config' in resp
@@ -41,7 +41,7 @@ async def test_get_resource_valid(test_client):
 async def test_get_resource_invalid_key(test_client):
     client = await test_client(create_app)
 
-    ddi = DDIClient(client.session, '{}:{}'.format(client.host, client.port), False, None, '/DEFAULT', 'test-target')
+    ddi = DDIClient(client.session, '{}:{}'.format(client.host, client.port), False, None, 'TargetToken', '/DEFAULT', 'test-target')
 
     with pytest.raises(KeyError):
         resp = await ddi.get_resource('{tenant}/controller/v1/{dummy}')
@@ -49,7 +49,7 @@ async def test_get_resource_invalid_key(test_client):
 async def test_get_resource_invalid_path(test_client):
     client = await test_client(create_app)
 
-    ddi = DDIClient(client.session, '{}:{}'.format(client.host, client.port), False, None, '/DEFAULT', 'test-target')
+    ddi = DDIClient(client.session, '{}:{}'.format(client.host, client.port), False, None, 'TargetToken', '/DEFAULT', 'test-target')
 
     with pytest.raises(APIError):
         resp = await ddi.get_resource('{tenant}/controller/v2')


### PR DESCRIPTION
Added a option if the target should authenticate through a GatewayToken
or a TargetToken, see
https://www.eclipse.org/hawkbit/concepts/authentication/ for more
information about the different "Token-Types".

The Type can be determined by adding the following option to the
config-File of the client:
auth_token_type = $TYPE
The folowing Types can be used: GatewayToken, TargetToken

If the option is not specified it will not break the program, instead it
tries to authenticate via TargetToken. This is to prevent errors when
updating the program with existing configs.

Signed-off-by: Max Hampel <hampel5275@gmail.com> #24 